### PR TITLE
Fixed Incorrect package="com.jeffg.emoji_picker" found in source Andr…

### DIFF
--- a/.dart_tool/extension_discovery/README.md
+++ b/.dart_tool/extension_discovery/README.md
@@ -1,0 +1,31 @@
+Extension Discovery Cache
+=========================
+
+This folder is used by `package:extension_discovery` to cache lists of
+packages that contains extensions for other packages.
+
+DO NOT USE THIS FOLDER
+----------------------
+
+ * Do not read (or rely) the contents of this folder.
+ * Do write to this folder.
+
+If you're interested in the lists of extensions stored in this folder use the
+API offered by package `extension_discovery` to get this information.
+
+If this package doesn't work for your use-case, then don't try to read the
+contents of this folder. It may change, and will not remain stable.
+
+Use package `extension_discovery`
+---------------------------------
+
+If you want to access information from this folder.
+
+Feel free to delete this folder
+-------------------------------
+
+Files in this folder act as a cache, and the cache is discarded if the files
+are older than the modification time of `.dart_tool/package_config.json`.
+
+Hence, it should never be necessary to clear this cache manually, if you find a
+need to do please file a bug.

--- a/.dart_tool/extension_discovery/vs_code.json
+++ b/.dart_tool/extension_discovery/vs_code.json
@@ -1,0 +1,1 @@
+{"version":2,"entries":[{"package":"emoji_picker","rootUri":"../","packageUri":"lib/"}]}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.1.1] - 01/23/2025
+* Fixed Incorrect package="com.jeffg.emoji_picker" found in source AndroidManifest.xml
+
 ## [0.1.0] - 09/01/2020
 * Added documentation
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.jeffg.emoji_picker">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
…oidManifest.xml

Setting the namespace via the package attribute in the source AndroidManifest.xml is no longer supported.